### PR TITLE
Fixed an access level to subscriptions

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -10,28 +10,29 @@ import (
 )
 
 type data struct {
-	FuncName, Args, Format, Type, Channel string
+	FuncName, Args, Format, Type, AccessLevel, Channel string
 }
 
 var subscriptions = map[string]struct {
 	funcName, notificationType string
+	isPrivate                  bool
 }{
-	"book.{instrument_name}.{group}.{depth}.{interval}": {"BookGroup", "BookNotification"},
-	"book.{instrument_name}.{interval}":                 {"BookInterval", "BookNotificationRaw"},
-	"deribit_price_index.{index_name}":                  {"DeribitPriceIndex", "DeribitPriceIndexNotification"},
-	"deribit_price_ranking.{index_name}":                {"DeribitPriceRanking", "DeribitPriceRankingNotification"},
-	"estimated_expiration_price.{index_name}":           {"EstimatedExpirationPrice", "EstimatedExpirationPriceNotification"},
-	"markprice.options.{index_name}":                    {"MarkPriceOptions", "MarkpriceOptionsNotification"},
-	"perpetual.{instrument_name}.{interval}":            {"Perpetual", "PerpetualNotification"},
-	"quote.{instrument_name}":                           {"Quote", "QuoteNotification"},
-	"ticker.{instrument_name}.{interval}":               {"Ticker", "TickerNotification"},
-	"trades.{instrument_name}.{interval}":               {"Trades", "PublicTrade"},
-	"user.orders.{instrument_name}.{interval}":          {"UserOrdersInstrumentName", "Order"},
-	"user.orders.{kind}.{currency}.{interval}":          {"UserOrdersKind", "Order"},
-	"user.portfolio.{currency}":                         {"UserPortfolio", "UserPortfolioNotification"},
-	"user.trades.{instrument_name}.{interval}":          {"UserTradesInstrument", "UserTrade"},
-	"user.trades.{kind}.{currency}.{interval}":          {"UserTradesKind", "UserTrade"},
-	"announcements":                                     {"Announcements", "AnnouncementNotification"},
+	"book.{instrument_name}.{group}.{depth}.{interval}": {"BookGroup", "BookNotification", false},
+	"book.{instrument_name}.{interval}":                 {"BookInterval", "BookNotificationRaw", false},
+	"deribit_price_index.{index_name}":                  {"DeribitPriceIndex", "DeribitPriceIndexNotification", false},
+	"deribit_price_ranking.{index_name}":                {"DeribitPriceRanking", "DeribitPriceRankingNotification", false},
+	"estimated_expiration_price.{index_name}":           {"EstimatedExpirationPrice", "EstimatedExpirationPriceNotification", false},
+	"markprice.options.{index_name}":                    {"MarkPriceOptions", "MarkpriceOptionsNotification", false},
+	"perpetual.{instrument_name}.{interval}":            {"Perpetual", "PerpetualNotification", false},
+	"quote.{instrument_name}":                           {"Quote", "QuoteNotification", false},
+	"ticker.{instrument_name}.{interval}":               {"Ticker", "TickerNotification", false},
+	"trades.{instrument_name}.{interval}":               {"Trades", "PublicTrade", false},
+	"user.orders.{instrument_name}.{interval}":          {"UserOrdersInstrumentName", "Order", true},
+	"user.orders.{kind}.{currency}.{interval}":          {"UserOrdersKind", "Order", true},
+	"user.portfolio.{currency}":                         {"UserPortfolio", "UserPortfolioNotification", true},
+	"user.trades.{instrument_name}.{interval}":          {"UserTradesInstrument", "UserTrade", true},
+	"user.trades.{kind}.{currency}.{interval}":          {"UserTradesKind", "UserTrade", true},
+	"announcements":                                     {"Announcements", "AnnouncementNotification", true},
 }
 
 func main() {
@@ -44,6 +45,10 @@ func main() {
 		d.Channel = c
 		d.FuncName = "Subscribe" + params.funcName
 		d.Type = params.notificationType
+		d.AccessLevel = "Public"
+		if params.isPrivate {
+			d.AccessLevel = "Private"
+		}
 		re := regexp.MustCompile(`\{(.*?)\}`)
 		match := re.FindAllStringSubmatch(c, -1)
 		if len(match) > 0 {
@@ -75,7 +80,7 @@ func (e *Exchange) {{.FuncName}}({{.Args}}{{if .Args}} string{{end}}) (chan *mod
 	e.subscriptions[chans[0]] = sub
 
     client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+	if _, err := client.Get{{.AccessLevel}}Subscribe(&operations.Get{{.AccessLevel}}SubscribeParams{Channels: chans}); err != nil {
 		delete(e.subscriptions, chans[0])
 		return nil, fmt.Errorf("error subscribing to channel: %s", err)
 	}

--- a/rpc_subscriptions.go
+++ b/rpc_subscriptions.go
@@ -10,12 +10,12 @@ import (
 	"github.com/adampointer/go-deribit/models"
 )
 
-// SubscribeBookInterval subscribes to the book.{instrument_name}.{interval} channel
-func (e *Exchange) SubscribeBookInterval(instrument_name, interval string) (chan *models.BookNotificationRaw, error) {
-	chans := []string{fmt.Sprintf("book.%s.%s", instrument_name, interval)}
+// SubscribeDeribitPriceIndex subscribes to the deribit_price_index.{index_name} channel
+func (e *Exchange) SubscribeDeribitPriceIndex(index_name string) (chan *models.DeribitPriceIndexNotification, error) {
+	chans := []string{fmt.Sprintf("deribit_price_index.%s", index_name)}
 
 	c := make(chan *RPCNotification)
-	out := make(chan *models.BookNotificationRaw)
+	out := make(chan *models.DeribitPriceIndexNotification)
 	sub := &RPCSubscription{Data: c, Channel: chans[0]}
 	e.subscriptions[chans[0]] = sub
 
@@ -30,275 +30,28 @@ func (e *Exchange) SubscribeBookInterval(instrument_name, interval string) (chan
 		for {
 			select {
 			case n := <-c:
-				var ret models.BookNotificationRaw
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeQuote subscribes to the quote.{instrument_name} channel
-func (e *Exchange) SubscribeQuote(instrument_name string) (chan *models.QuoteNotification, error) {
-	chans := []string{fmt.Sprintf("quote.%s", instrument_name)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.QuoteNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.QuoteNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.DeribitPriceIndexNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.DeribitPriceIndexNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
 				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeUserTradesInstrument subscribes to the user.trades.{instrument_name}.{interval} channel
-func (e *Exchange) SubscribeUserTradesInstrument(instrument_name, interval string) (chan *models.UserTrade, error) {
-	chans := []string{fmt.Sprintf("user.trades.%s.%s", instrument_name, interval)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.UserTrade)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.UserTrade
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeTrades subscribes to the trades.{instrument_name}.{interval} channel
-func (e *Exchange) SubscribeTrades(instrument_name, interval string) (chan *models.PublicTrade, error) {
-	chans := []string{fmt.Sprintf("trades.%s.%s", instrument_name, interval)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.PublicTrade)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.PublicTrade
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeUserOrdersKind subscribes to the user.orders.{kind}.{currency}.{interval} channel
-func (e *Exchange) SubscribeUserOrdersKind(kind, currency, interval string) (chan *models.Order, error) {
-	chans := []string{fmt.Sprintf("user.orders.%s.%s.%s", kind, currency, interval)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.Order)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.Order
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeAnnouncements subscribes to the announcements channel
-func (e *Exchange) SubscribeAnnouncements(kind, currency, interval string) (chan *models.AnnouncementNotification, error) {
-	chans := []string{fmt.Sprintf("announcements", kind, currency, interval)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.AnnouncementNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.AnnouncementNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeDeribitPriceRanking subscribes to the deribit_price_ranking.{index_name} channel
-func (e *Exchange) SubscribeDeribitPriceRanking(index_name string) (chan *models.DeribitPriceRankingNotification, error) {
-	chans := []string{fmt.Sprintf("deribit_price_ranking.%s", index_name)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.DeribitPriceRankingNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.DeribitPriceRankingNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeEstimatedExpirationPrice subscribes to the estimated_expiration_price.{index_name} channel
-func (e *Exchange) SubscribeEstimatedExpirationPrice(index_name string) (chan *models.EstimatedExpirationPriceNotification, error) {
-	chans := []string{fmt.Sprintf("estimated_expiration_price.%s", index_name)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.EstimatedExpirationPriceNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.EstimatedExpirationPriceNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeMarkPriceOptions subscribes to the markprice.options.{index_name} channel
-func (e *Exchange) SubscribeMarkPriceOptions(index_name string) (chan *models.MarkpriceOptionsNotification, error) {
-	chans := []string{fmt.Sprintf("markprice.options.%s", index_name)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.MarkpriceOptionsNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.MarkpriceOptionsNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
-				}
-				out <- &ret
 			case <-e.stop:
 				break Loop
 			}
@@ -327,11 +80,78 @@ func (e *Exchange) SubscribeTicker(instrument_name, interval string) (chan *mode
 		for {
 			select {
 			case n := <-c:
-				var ret models.TickerNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.TickerNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.TickerNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeUserOrdersKind subscribes to the user.orders.{kind}.{currency}.{interval} channel
+func (e *Exchange) SubscribeUserOrdersKind(kind, currency, interval string) (chan *models.Order, error) {
+	chans := []string{fmt.Sprintf("user.orders.%s.%s.%s", kind, currency, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.Order)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.Order
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.Order
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
 			case <-e.stop:
 				break Loop
 			}
@@ -360,11 +180,28 @@ func (e *Exchange) SubscribeUserTradesKind(kind, currency, interval string) (cha
 		for {
 			select {
 			case n := <-c:
-				var ret models.UserTrade
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.UserTrade
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.UserTrade
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
 			case <-e.stop:
 				break Loop
 			}
@@ -373,12 +210,12 @@ func (e *Exchange) SubscribeUserTradesKind(kind, currency, interval string) (cha
 	return out, nil
 }
 
-// SubscribeBookGroup subscribes to the book.{instrument_name}.{group}.{depth}.{interval} channel
-func (e *Exchange) SubscribeBookGroup(instrument_name, group, depth, interval string) (chan *models.BookNotification, error) {
-	chans := []string{fmt.Sprintf("book.%s.%s.%s.%s", instrument_name, group, depth, interval)}
+// SubscribeEstimatedExpirationPrice subscribes to the estimated_expiration_price.{index_name} channel
+func (e *Exchange) SubscribeEstimatedExpirationPrice(index_name string) (chan *models.EstimatedExpirationPriceNotification, error) {
+	chans := []string{fmt.Sprintf("estimated_expiration_price.%s", index_name)}
 
 	c := make(chan *RPCNotification)
-	out := make(chan *models.BookNotification)
+	out := make(chan *models.EstimatedExpirationPriceNotification)
 	sub := &RPCSubscription{Data: c, Channel: chans[0]}
 	e.subscriptions[chans[0]] = sub
 
@@ -393,44 +230,28 @@ func (e *Exchange) SubscribeBookGroup(instrument_name, group, depth, interval st
 		for {
 			select {
 			case n := <-c:
-				var ret models.BookNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
-			case <-e.stop:
-				break Loop
-			}
-		}
-	}()
-	return out, nil
-}
-
-// SubscribeDeribitPriceIndex subscribes to the deribit_price_index.{index_name} channel
-func (e *Exchange) SubscribeDeribitPriceIndex(index_name string) (chan *models.DeribitPriceIndexNotification, error) {
-	chans := []string{fmt.Sprintf("deribit_price_index.%s", index_name)}
-
-	c := make(chan *RPCNotification)
-	out := make(chan *models.DeribitPriceIndexNotification)
-	sub := &RPCSubscription{Data: c, Channel: chans[0]}
-	e.subscriptions[chans[0]] = sub
-
-	client := e.Client()
-	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
-		delete(e.subscriptions, chans[0])
-		return nil, fmt.Errorf("error subscribing to channel: %s", err)
-	}
-
-	go func() {
-	Loop:
-		for {
-			select {
-			case n := <-c:
-				var ret models.DeribitPriceIndexNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.EstimatedExpirationPriceNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.EstimatedExpirationPriceNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
 				}
-				out <- &ret
 			case <-e.stop:
 				break Loop
 			}
@@ -459,11 +280,28 @@ func (e *Exchange) SubscribePerpetual(instrument_name, interval string) (chan *m
 		for {
 			select {
 			case n := <-c:
-				var ret models.PerpetualNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.PerpetualNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.PerpetualNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
 			case <-e.stop:
 				break Loop
 			}
@@ -472,17 +310,17 @@ func (e *Exchange) SubscribePerpetual(instrument_name, interval string) (chan *m
 	return out, nil
 }
 
-// SubscribeUserOrdersInstrumentName subscribes to the user.orders.{instrument_name}.{interval} channel
-func (e *Exchange) SubscribeUserOrdersInstrumentName(instrument_name, interval string) (chan *models.Order, error) {
-	chans := []string{fmt.Sprintf("user.orders.%s.%s", instrument_name, interval)}
+// SubscribeTrades subscribes to the trades.{instrument_name}.{interval} channel
+func (e *Exchange) SubscribeTrades(instrument_name, interval string) (chan *models.PublicTrade, error) {
+	chans := []string{fmt.Sprintf("trades.%s.%s", instrument_name, interval)}
 
 	c := make(chan *RPCNotification)
-	out := make(chan *models.Order)
+	out := make(chan *models.PublicTrade)
 	sub := &RPCSubscription{Data: c, Channel: chans[0]}
 	e.subscriptions[chans[0]] = sub
 
 	client := e.Client()
-	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
 		delete(e.subscriptions, chans[0])
 		return nil, fmt.Errorf("error subscribing to channel: %s", err)
 	}
@@ -492,11 +330,28 @@ func (e *Exchange) SubscribeUserOrdersInstrumentName(instrument_name, interval s
 		for {
 			select {
 			case n := <-c:
-				var ret models.Order
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.PublicTrade
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.PublicTrade
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
 			case <-e.stop:
 				break Loop
 			}
@@ -525,11 +380,428 @@ func (e *Exchange) SubscribeUserPortfolio(currency string) (chan *models.UserPor
 		for {
 			select {
 			case n := <-c:
-				var ret models.UserPortfolioNotification
-				if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
-					e.errors <- fmt.Errorf("error decoding notification: %s", err)
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
 				}
-				out <- &ret
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.UserPortfolioNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.UserPortfolioNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeBookGroup subscribes to the book.{instrument_name}.{group}.{depth}.{interval} channel
+func (e *Exchange) SubscribeBookGroup(instrument_name, group, depth, interval string) (chan *models.BookNotification, error) {
+	chans := []string{fmt.Sprintf("book.%s.%s.%s.%s", instrument_name, group, depth, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.BookNotification)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.BookNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.BookNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeBookInterval subscribes to the book.{instrument_name}.{interval} channel
+func (e *Exchange) SubscribeBookInterval(instrument_name, interval string) (chan *models.BookNotificationRaw, error) {
+	chans := []string{fmt.Sprintf("book.%s.%s", instrument_name, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.BookNotificationRaw)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.BookNotificationRaw
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.BookNotificationRaw
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeQuote subscribes to the quote.{instrument_name} channel
+func (e *Exchange) SubscribeQuote(instrument_name string) (chan *models.QuoteNotification, error) {
+	chans := []string{fmt.Sprintf("quote.%s", instrument_name)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.QuoteNotification)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.QuoteNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.QuoteNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeUserOrdersInstrumentName subscribes to the user.orders.{instrument_name}.{interval} channel
+func (e *Exchange) SubscribeUserOrdersInstrumentName(instrument_name, interval string) (chan *models.Order, error) {
+	chans := []string{fmt.Sprintf("user.orders.%s.%s", instrument_name, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.Order)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.Order
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.Order
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeUserTradesInstrument subscribes to the user.trades.{instrument_name}.{interval} channel
+func (e *Exchange) SubscribeUserTradesInstrument(instrument_name, interval string) (chan *models.UserTrade, error) {
+	chans := []string{fmt.Sprintf("user.trades.%s.%s", instrument_name, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.UserTrade)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.UserTrade
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.UserTrade
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeAnnouncements subscribes to the announcements channel
+func (e *Exchange) SubscribeAnnouncements(instrument_name, interval string) (chan *models.AnnouncementNotification, error) {
+	chans := []string{fmt.Sprintf("announcements", instrument_name, interval)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.AnnouncementNotification)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPrivateSubscribe(&operations.GetPrivateSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.AnnouncementNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.AnnouncementNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeDeribitPriceRanking subscribes to the deribit_price_ranking.{index_name} channel
+func (e *Exchange) SubscribeDeribitPriceRanking(index_name string) (chan *models.DeribitPriceRankingNotification, error) {
+	chans := []string{fmt.Sprintf("deribit_price_ranking.%s", index_name)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.DeribitPriceRankingNotification)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.DeribitPriceRankingNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.DeribitPriceRankingNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
+			case <-e.stop:
+				break Loop
+			}
+		}
+	}()
+	return out, nil
+}
+
+// SubscribeMarkPriceOptions subscribes to the markprice.options.{index_name} channel
+func (e *Exchange) SubscribeMarkPriceOptions(index_name string) (chan *models.MarkpriceOptionsNotification, error) {
+	chans := []string{fmt.Sprintf("markprice.options.%s", index_name)}
+
+	c := make(chan *RPCNotification)
+	out := make(chan *models.MarkpriceOptionsNotification)
+	sub := &RPCSubscription{Data: c, Channel: chans[0]}
+	e.subscriptions[chans[0]] = sub
+
+	client := e.Client()
+	if _, err := client.GetPublicSubscribe(&operations.GetPublicSubscribeParams{Channels: chans}); err != nil {
+		delete(e.subscriptions, chans[0])
+		return nil, fmt.Errorf("error subscribing to channel: %s", err)
+	}
+
+	go func() {
+	Loop:
+		for {
+			select {
+			case n := <-c:
+				if len(n.Params.Data) < 1 {
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+					continue
+				}
+				switch byte(n.Params.Data[0]) {
+				case '{':
+					var ret models.MarkpriceOptionsNotification
+					if err := json.Unmarshal(n.Params.Data, &ret); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					out <- &ret
+				case '[':
+					var rets []models.MarkpriceOptionsNotification
+					if err := json.Unmarshal(n.Params.Data, &rets); err != nil {
+						e.errors <- fmt.Errorf("error decoding notification: %s", err)
+					}
+					for _, ret := range rets {
+						out <- &ret
+					}
+				default:
+					e.errors <- fmt.Errorf("invalid json data: %s", string(n.Params.Data))
+				}
 			case <-e.stop:
 				break Loop
 			}


### PR DESCRIPTION
**The issue:** in `cmd/gen/main.go` the `subscriptionTemplate` was hard coded only with public access to any subscription, but some of them has a private access.

**Solution:** Added `AccessLevel` to distinguish public and private subscriptions.

Also on master branch: a decode fails to most of subscriptions with error: 
```bash
RPC Error: error decoding notification: a slice, expected a map
```  
the error is coming from here:
```go
if err := mapstructure.Decode(n.Params.Data, &ret); err != nil {
					e.errors <- fmt.Errorf("error decoding notification: %s", err)
				}
```
and it occurs, because  `n.Params.Data` is json.RawMessage, i.e. slice of byte. And even if I unmarshal json.RawMessage to map[string]interface{} before,  `mapstructure` skips some fields while decoding.

But anyway, your initial template had the std lib json.Unmarshal which is working fine. 