### PR TITLE
added feature: reconnect deribit.Exchange

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -19,6 +19,8 @@ var ErrTimeout = errors.New("timed out waiting for a response")
 
 // Exchange is an API wrapper with the exchange
 type Exchange struct {
+	OnDisconnect func(*Exchange) // triggers on a failed read from connection
+
 	url           string
 	test          bool
 	conn          *websocket.Conn

--- a/rpc_core.go
+++ b/rpc_core.go
@@ -8,6 +8,7 @@ import (
 	"github.com/adampointer/go-deribit/client/operations"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
 )
 
@@ -90,7 +91,11 @@ Loop:
 				if isTemporary(err) {
 					continue
 				}
-				if f := e.OnDisconnect; f != nil {
+				// stop reading if a close message sent from server
+				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+					break Loop
+				}
+				if f := e.OnDisconnect; f != nil { // reconnect
 					f(e)
 				}
 				break Loop


### PR DESCRIPTION
Provided `OnDisconnect` callback to reconnect the client.

Usage example:
```go
func reconnect(e *deribit.Exchange) {
	// stop, close a previous client
	// connect a new client
	// subscribe all desired channels, etc
}

exchange, _ = deribit.NewExchange(true, err, stop)
exchange.OnDisconnect = reconnect
```