### PR TITLE
v3/rpc_core.go: fixed silent error on subscription failure

### DIFF
--- a/rpc_core.go
+++ b/rpc_core.go
@@ -108,6 +108,9 @@ Loop:
 					Result:  raw.Result,
 					Error:   raw.Error,
 				}
+				if len(res.Result) <= 2 && res.Error == nil {
+					res.Error = &RPCError{Code: 10001, Message: "empty result"}
+				}
 				e.mutex.Lock()
 				call := e.pending[res.ID]
 				e.mutex.Unlock()

--- a/v3/rpc_core.go
+++ b/v3/rpc_core.go
@@ -108,6 +108,9 @@ Loop:
 					Result:  raw.Result,
 					Error:   raw.Error,
 				}
+				if len(res.Result) <= 2 && res.Error == nil {
+					res.Error = &RPCError{Code: 10001, Message: "empty result"}
+				}
 				e.mutex.Lock()
 				call := e.pending[res.ID]
 				e.mutex.Unlock()


### PR DESCRIPTION
**The issue:** the api doesn't provide a proper error on subscription failure, just sends an empty `result` in response.

**Solution**: Added an error for this case. Assigned `10001` code error, because there is `no public information available`. 

Such errors may happen an subscribe/unsubscribe for different reasons.