### PR TITLE
fixed schema: contract size type

### DIFF
--- a/models/contract_size.go
+++ b/models/contract_size.go
@@ -11,7 +11,7 @@ import (
 
 // ContractSize Contract size, for futures in USD, for options in BTC.
 // swagger:model contract_size
-type ContractSize int64
+type ContractSize float64
 
 // Validate validates this contract size
 func (m ContractSize) Validate(formats strfmt.Registry) error {

--- a/models/instrument.go
+++ b/models/instrument.go
@@ -26,7 +26,7 @@ type Instrument struct {
 
 	// Contract size for instrument
 	// Required: true
-	ContractSize *int64 `json:"contract_size"`
+	ContractSize *float64 `json:"contract_size"`
 
 	// The time when the instrument was first created (milliseconds)
 	// Required: true

--- a/schema/schema_clean.json
+++ b/schema/schema_clean.json
@@ -4541,7 +4541,7 @@
             "description": "specifies minimal price change and, as follows, the number of decimal places for instrument prices"
           },
           "contract_size": {
-            "type": "integer",
+            "type": "number",
             "description": "Contract size for instrument",
             "example": 1
           },
@@ -7787,7 +7787,7 @@
         "description": "Whether the stop order has been triggered (Only for stop orders)"
       },
       "contract_size": {
-        "type": "integer",
+        "type": "number",
         "description": "Contract size, for futures in USD, for options in BTC.",
         "example": 10
       },

--- a/schema/swagger.json
+++ b/schema/swagger.json
@@ -4754,7 +4754,7 @@
     "contract_size": {
       "description": "Contract size, for futures in USD, for options in BTC.",
       "example": 10,
-      "type": "integer"
+      "type": "number"
     },
     "cumulative_amount": {
       "description": "The cumulative amount of all orders up till given price",
@@ -5125,7 +5125,7 @@
         "contract_size": {
           "description": "Contract size for instrument",
           "example": 1,
-          "type": "integer"
+          "type": "number"
         },
         "creation_timestamp": {
           "description": "The time when the instrument was first created (milliseconds)",

--- a/v3/models/contract_size.go
+++ b/v3/models/contract_size.go
@@ -11,7 +11,7 @@ import (
 
 // ContractSize Contract size, for futures in USD, for options in BTC.
 // swagger:model contract_size
-type ContractSize int64
+type ContractSize float64
 
 // Validate validates this contract size
 func (m ContractSize) Validate(formats strfmt.Registry) error {

--- a/v3/schema/swagger.json
+++ b/v3/schema/swagger.json
@@ -5026,7 +5026,7 @@
     "contract_size": {
       "description": "Contract size, for futures in USD, for options in BTC.",
       "example": 10,
-      "type": "integer"
+      "type": "number"
     },
     "currency": {
       "description": "Currency, i.e `\"BTC\"`, `\"ETH\"`",


### PR DESCRIPTION
**The issue:** std lib json unmarshals `integer` values to `float64` type, so type assertion to `int64` getting screwed.

Timestamps unmarshlling good to `integer` through.