### PR TITLE
Improved deribit.Exchange reconnect

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -32,6 +32,7 @@ type Exchange struct {
 	stop          chan bool
 	auth          *models.PublicAuthResponseResult
 	client        *operations.Client
+	isClosed      bool
 }
 
 // NewExchange creates a new API wrapper
@@ -68,6 +69,10 @@ func (e *Exchange) Connect() error {
 
 // Close the websocket connection
 func (e *Exchange) Close() error {
+	e.mutex.Lock()
+	e.isClosed = true
+	e.mutex.Unlock()
+
 	if err := e.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
 		return err
 	}

--- a/v3/exchange.go
+++ b/v3/exchange.go
@@ -32,6 +32,7 @@ type Exchange struct {
 	stop          chan bool
 	auth          *models.PublicAuthResponse
 	client        *operations.Client
+	isClosed      bool
 }
 
 // NewExchange creates a new API wrapper
@@ -68,6 +69,10 @@ func (e *Exchange) Connect() error {
 
 // Close the websocket connection
 func (e *Exchange) Close() error {
+	e.mutex.Lock()
+	e.isClosed = true
+	e.mutex.Unlock()
+
 	if err := e.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
 		return err
 	}


### PR DESCRIPTION
 - Added `isClosed` to distinguish a closure, initiated by the client.
 - break the reading loop only if the client initiated a closure
 - added fix for net.Error: `use of closed network connection`. Since we're not waiting for a close message from server, the connection can be broken before the close message comes. The implementation of waiting for the close message from server would be much complex and has no sense.

**Changed the reconnect behavior:**
**Before:** break the reading loop if _server_ initiated a closure and reconnect if _client_ does.
**Now:** break the reading loop if the _client_ initiated a closure and reconnect if _server_ does.

Can you please tag the changes, if you will accept them? You can tag the same commit with v2 and v3 tags, as I understood you decided to maintain both of them. 