### PR TITLE
fixed an error on empty response/result for endpoints

### DIFF
--- a/v3/rpc_core.go
+++ b/v3/rpc_core.go
@@ -115,12 +115,16 @@ Loop:
 					Result:  raw.Result,
 					Error:   raw.Error,
 				}
-				if len(res.Result) <= 2 && res.Error == nil {
-					res.Error = &RPCError{Code: 10001, Message: "empty result"}
-				}
+
 				e.mutex.Lock()
 				call := e.pending[res.ID]
 				e.mutex.Unlock()
+
+				if strings.Contains(call.Req.Method, "subscribe") {
+					if len(res.Result) <= 2 && res.Error == nil {
+						res.Error = &RPCError{Code: 10001, Message: "empty result"}
+					}
+				}
 
 				if res.Error != nil && res.Error.Code != 0 {
 					resErr = fmt.Errorf("request failed with code (%d): %s", res.Error.Code, res.Error.Message)


### PR DESCRIPTION
Made an empty response/result to error out only for subscriptions, because for some endpoints it can be a valid response. For example, `/private/get_open_orders_by_currency`.