### PR TITLE
fixed raw orderbook schema

### DIFF
--- a/v3/models/book_notification_raw.go
+++ b/v3/models/book_notification_raw.go
@@ -21,11 +21,11 @@ type BookNotificationRaw struct {
 
 	// asks
 	// Required: true
-	Asks []float64 `json:"asks"`
+	Asks [][]interface{} `json:"asks"`
 
 	// bids
 	// Required: true
-	Bids []float64 `json:"bids"`
+	Bids [][]interface{} `json:"bids"`
 
 	// Identifier of the notification
 	// Required: true

--- a/v3/schema/swagger.json
+++ b/v3/schema/swagger.json
@@ -7438,14 +7438,16 @@
         "asks": {
           "items": {
             "description": "The first notification will contain the amounts for all price levels (a list of [\"new\", price, amount] tuples). All following notifications will contain a list of tuples with action, price level and new amount ([action, price, amount]). Action can be `new`, `change` or `delete`.",
-            "type": "number"
+            "type": "array",
+            "items":{}
           },
           "type": "array"
         },
         "bids": {
           "items": {
             "description": "(See 'asks' above.)",
-            "type": "number"
+            "type": "array",
+            "items":{}
           },
           "type": "array"
         },


### PR DESCRIPTION
**The issue:** the current schema on master branch skips an action item in raw orderbook entry, because a `string` can't be unmarshal to `number`.

An example of raw orderbook entry from docs:
```
[
          "new",
          5042.34,
          30
        ]
```
i.e. `[action, price, amount]`.

The only solution I found is to unmarshal to `interface{}`, i.e. `items:{}`. Because swagger v2 doesn't allow to unmarshal a json array of different types. And I don't think that even `oneOf` from swagger v3 could help to solve it. Only a proper unmarshal of json array with a way to define an order of items and type of each item, which I haven't found as a part of swagger spec.

Looks a bit nasty, but it works at least. 